### PR TITLE
[Enhancement] Do not ping admins upon update

### DIFF
--- a/src/main/java/com/xujiayao/discord_mc_chat/Config.java
+++ b/src/main/java/com/xujiayao/discord_mc_chat/Config.java
@@ -57,7 +57,7 @@ public class Config {
 		public boolean whitelistRequiresAdmin = true;
 
 		public boolean notifyUpdates = true;
-		public boolean mentionAdminsForUpdates = true;
+		public boolean mentionAdminsForUpdates = false;
 
 		public boolean updateChannelTopic = true;
 		public int channelTopicUpdateInterval = 600000;


### PR DESCRIPTION
<!-- New Feature or Bug Fix Pull Request -->
<!-- Implement an idea for this project or implement a bug fix to help us improve. -->
<!---->
<!-- Insert "[Enhancement] " or "[Bug] " before the first word in the title. -->
<!-- Note that the PR may be closed directly if you do not follow the instructions. -->

### Checks

<!-- Please check that you have done the following things before submitting a pull request. -->
<!-- Set [ ] to [X] -->

- [X] I confirm that I have [searched for existing issues / pull requests](https://github.com/Xujiayao/Discord-MC-Chat/issues?q=) before requesting to avoid duplicate requesting.
- [X] I confirm that I noted that if I don't follow the instructions, the issue may be closed directly.

### Related Issues

<!-- Any GitHub issues related to this PR? If not, please fill in N/A. -->
<!-- Example: Fixes #ISSUE-NUMBER -->

Related to #61 

### Description

Disabled mentioning all admins by default -> can get very annoying

Update notifications are still sent

<!-- For Bug Fix Pull Request: -->
<!-- Please tell us what bug have you fixed with a clear and detailed description, add screenshots to help explain. -->
<!---->
<!-- For New Feature Pull Request: -->
<!-- What new feature or change have you added? What does it improve? Please tell us what the new feature or change is with a clear and detailed description, add screenshots to help explain if possible. -->